### PR TITLE
Fixes #1 - Exit bar containment on responsive preview

### DIFF
--- a/assets/js/granular-editor.min.js
+++ b/assets/js/granular-editor.min.js
@@ -9,11 +9,11 @@ window.onload = function(){
 		$("#elementor-preview").css("pointer-events", "none");
 		 $(document).ready(function() {
 			$("#granular-top-bar").draggable( {
-				snap: "#elementor-preview-iframe",
+				snap: "#elementor-preview, #elementor-preview-iframe",
 				opacity: 0.7,
 				addClasses: false,
-				containment: "iframe",
-				snapMode: "iframe",
+				containment: "#elementor-preview",
+				snapMode: "inner",
 				snapTolerance: 25,
 				edgeResistance: 2.4,
 				stop: function (event, ui) {


### PR DESCRIPTION
Added snapping to the preview element, not only the IFrame.
Contained the drag within the preview element, not only the IFrame.
Fixed the snapMode options to a valid value (should be either "inner", "outer" or "both").
Ref: https://api.jqueryui.com/draggable/